### PR TITLE
bump: version up dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "react-dom": "^19.1.0",
       },
       "devDependencies": {
-        "@types/node": "^22.15.17",
+        "@types/node": "^22.15.18",
         "@types/react": "^19.1.4",
         "typescript": "^5.8.3",
       },
@@ -116,7 +116,7 @@
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
-    "@types/node": ["@types/node@22.15.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wIX2aSZL5FE+MR0JlvF87BNVrtFWf6AE6rxSE9X7OwnVvoyCQjpzSRJ+M87se/4QCkCiebQAqrJ0y6fwIyi7nw=="],
+    "@types/node": ["@types/node@22.15.18", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-v1DKRfUdyW+jJhZNEI1PYy29S2YRxMV5AOO/x/SjKmW0acCIOqmbj6Haf9eHAhsPmrhlHSxEhv/1WszcLWV4cg=="],
 
     "@types/react": ["@types/react@19.1.4", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-EB1yiiYdvySuIITtD5lhW4yPyJ31RkJkkDw794LaQYrxCSaQV/47y5o1FMC4zF9ZyjUjzJMZwbovEnT5yHTW6g=="],
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
-    "@types/node": "^22.15.17",
+    "@types/node": "^22.15.18",
     "@types/react": "^19.1.4",
     "typescript": "^5.8.3"
   }


### PR DESCRIPTION
## Sourcery によるサマリー

開発依存関係を更新し、ロックファイルを更新

雑務:
- @types/node を 22.15.17 から 22.15.18 にアップグレード
- 依存関係の更新後、bun.lock を再生成

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bump development dependency and refresh lock file

Chores:
- Upgrade @types/node from 22.15.17 to 22.15.18
- Regenerate bun.lock after dependency bump

</details>